### PR TITLE
feat: lock primary screen from selection

### DIFF
--- a/src/Config.cs
+++ b/src/Config.cs
@@ -6,15 +6,22 @@ namespace BlackScreenSaver;
 public class AppConfig
 {
     /// <summary>
-    /// Index of the target screen to black out (0-based).
+    /// Indices of the target screens to black out (0-based).
+    /// Multiple screens can be selected.
     /// </summary>
-    public int TargetScreenIndex { get; set; } = 1;
+    public List<int> TargetScreenIndices { get; set; } = new() { 1 };
 
     /// <summary>
-    /// Number of seconds the cursor must be away from the target screen
+    /// Legacy property kept for backward-compatible deserialization.
+    /// If present in JSON it will be migrated into TargetScreenIndices.
+    /// </summary>
+    public int? TargetScreenIndex { get; set; }
+
+    /// <summary>
+    /// Number of seconds the cursor must be away from the target screens
     /// before the overlay appears.
     /// </summary>
-    public int InactivityTimeoutSeconds { get; set; } = 10;
+    public int InactivityTimeoutSeconds { get; set; } = 30;
 
     /// <summary>
     /// Whether the application should start with Windows.

--- a/src/ScreenLayoutPanel.cs
+++ b/src/ScreenLayoutPanel.cs
@@ -1,0 +1,212 @@
+namespace BlackScreenSaver;
+
+/// <summary>
+/// A custom panel that draws a miniature layout of all connected monitors
+/// in their real relative positions (like Windows Display Settings).
+/// Clicking a screen rectangle toggles its selection.
+/// </summary>
+public class ScreenLayoutPanel : Panel
+{
+    private readonly List<RectangleF> _scaledRects = new();
+    private readonly List<int> _screenIndices = new();
+
+    /// <summary>
+    /// The set of currently selected screen indices.
+    /// </summary>
+    public HashSet<int> SelectedIndices { get; set; } = new();
+
+    // Colors
+    private static readonly Color SelectedFill = Color.FromArgb(40, 100, 210);
+    private static readonly Color SelectedBorder = Color.FromArgb(60, 130, 255);
+    private static readonly Color UnselectedFill = Color.FromArgb(60, 60, 60);
+    private static readonly Color UnselectedBorder = Color.FromArgb(100, 100, 100);
+    private static readonly Color HoverFill = Color.FromArgb(80, 80, 80);
+    private static readonly Color PanelBackground = Color.FromArgb(30, 30, 30);
+
+    private static readonly Color LockedFill = Color.FromArgb(45, 45, 45);
+    private static readonly Color LockedBorder = Color.FromArgb(80, 80, 80);
+
+    private int _hoverIndex = -1;
+
+    /// <summary>
+    /// Screen indices that cannot be selected (e.g. the primary screen).
+    /// </summary>
+    public HashSet<int> LockedIndices { get; set; } = new();
+
+    public ScreenLayoutPanel()
+    {
+        DoubleBuffered = true;
+        BackColor = PanelBackground;
+        SetStyle(ControlStyles.ResizeRedraw, true);
+    }
+
+    /// <summary>
+    /// Recalculates the scaled rectangles for all screens to fit within the panel.
+    /// </summary>
+    private void RecalculateLayout()
+    {
+        _scaledRects.Clear();
+        _screenIndices.Clear();
+
+        Screen[] screens = Screen.AllScreens;
+        if (screens.Length == 0) return;
+
+        // Find bounding box of all screens in virtual desktop coords
+        int minX = int.MaxValue, minY = int.MaxValue;
+        int maxX = int.MinValue, maxY = int.MinValue;
+
+        foreach (Screen s in screens)
+        {
+            if (s.Bounds.Left < minX) minX = s.Bounds.Left;
+            if (s.Bounds.Top < minY) minY = s.Bounds.Top;
+            if (s.Bounds.Right > maxX) maxX = s.Bounds.Right;
+            if (s.Bounds.Bottom > maxY) maxY = s.Bounds.Bottom;
+        }
+
+        float totalW = maxX - minX;
+        float totalH = maxY - minY;
+        if (totalW <= 0 || totalH <= 0) return;
+
+        // Scale to fit the panel with padding
+        float padding = 16;
+        float availW = Width - padding * 2;
+        float availH = Height - padding * 2;
+
+        float scale = Math.Min(availW / totalW, availH / totalH);
+
+        // Center the drawing
+        float scaledTotalW = totalW * scale;
+        float scaledTotalH = totalH * scale;
+        float offsetX = (Width - scaledTotalW) / 2f;
+        float offsetY = (Height - scaledTotalH) / 2f;
+
+        for (int i = 0; i < screens.Length; i++)
+        {
+            Rectangle b = screens[i].Bounds;
+            float x = (b.X - minX) * scale + offsetX;
+            float y = (b.Y - minY) * scale + offsetY;
+            float w = b.Width * scale;
+            float h = b.Height * scale;
+
+            // Slight inset so adjacent screens have a visible gap
+            _scaledRects.Add(new RectangleF(x + 2, y + 2, w - 4, h - 4));
+            _screenIndices.Add(i);
+        }
+    }
+
+    protected override void OnPaint(PaintEventArgs e)
+    {
+        base.OnPaint(e);
+        RecalculateLayout();
+
+        Graphics g = e.Graphics;
+        g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+        g.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
+
+        Screen[] screens = Screen.AllScreens;
+
+        for (int i = 0; i < _scaledRects.Count; i++)
+        {
+            RectangleF rect = _scaledRects[i];
+            int screenIdx = _screenIndices[i];
+            bool locked = LockedIndices.Contains(screenIdx);
+            bool selected = !locked && SelectedIndices.Contains(screenIdx);
+            bool hovered = !locked && _hoverIndex == screenIdx;
+
+            // Fill
+            Color fill = locked ? LockedFill : selected ? SelectedFill : (hovered ? HoverFill : UnselectedFill);
+            using var brush = new SolidBrush(fill);
+            g.FillRectangle(brush, rect);
+
+            // Border
+            Color border = locked ? LockedBorder : selected ? SelectedBorder : UnselectedBorder;
+            using var pen = new Pen(border, selected ? 2f : 1f);
+            g.DrawRectangle(pen, rect.X, rect.Y, rect.Width, rect.Height);
+
+            // Labels
+            string label = (screenIdx + 1).ToString();
+            string sub = screens[screenIdx].Primary ? "Primary" : "";
+            string res = $"{screens[screenIdx].Bounds.Width}×{screens[screenIdx].Bounds.Height}";
+
+            using var labelFont = new Font("Segoe UI", Math.Max(rect.Height * 0.22f, 10f), FontStyle.Bold);
+            using var subFont = new Font("Segoe UI", Math.Max(rect.Height * 0.11f, 7f), FontStyle.Regular);
+            using var labelBrush = new SolidBrush(selected ? Color.White : Color.FromArgb(180, 180, 180));
+            using var subBrush = new SolidBrush(selected ? Color.FromArgb(200, 220, 255) : Color.FromArgb(130, 130, 130));
+
+            var sf = new StringFormat
+            {
+                Alignment = StringAlignment.Center,
+                LineAlignment = StringAlignment.Center
+            };
+
+            // Screen number — centered, slightly above middle
+            var labelRect = new RectangleF(rect.X, rect.Y, rect.Width, rect.Height * 0.65f);
+            g.DrawString(label, labelFont, labelBrush, labelRect, sf);
+
+            // Sub-label (Primary / resolution) — below middle
+            if (locked) sub = "Primary (locked)";
+            string info = string.IsNullOrEmpty(sub) ? res : $"{sub}\n{res}";
+            var subRect = new RectangleF(rect.X, rect.Y + rect.Height * 0.50f, rect.Width, rect.Height * 0.45f);
+            g.DrawString(info, subFont, subBrush, subRect, sf);
+        }
+    }
+
+    protected override void OnMouseClick(MouseEventArgs e)
+    {
+        base.OnMouseClick(e);
+
+        for (int i = 0; i < _scaledRects.Count; i++)
+        {
+            if (_scaledRects[i].Contains(e.Location))
+            {
+                int idx = _screenIndices[i];
+
+                // Primary screen cannot be selected
+                if (LockedIndices.Contains(idx))
+                    return;
+
+                if (SelectedIndices.Contains(idx))
+                    SelectedIndices.Remove(idx);
+                else
+                    SelectedIndices.Add(idx);
+
+                Invalidate();
+                return;
+            }
+        }
+    }
+
+    protected override void OnMouseMove(MouseEventArgs e)
+    {
+        base.OnMouseMove(e);
+
+        int newHover = -1;
+        for (int i = 0; i < _scaledRects.Count; i++)
+        {
+            if (_scaledRects[i].Contains(e.Location))
+            {
+                newHover = _screenIndices[i];
+                break;
+            }
+        }
+
+        if (newHover != _hoverIndex)
+        {
+            _hoverIndex = newHover;
+            bool isLocked = _hoverIndex >= 0 && LockedIndices.Contains(_hoverIndex);
+            Cursor = _hoverIndex >= 0 && !isLocked ? Cursors.Hand : Cursors.Default;
+            Invalidate();
+        }
+    }
+
+    protected override void OnMouseLeave(EventArgs e)
+    {
+        base.OnMouseLeave(e);
+        if (_hoverIndex >= 0)
+        {
+            _hoverIndex = -1;
+            Cursor = Cursors.Default;
+            Invalidate();
+        }
+    }
+}

--- a/src/ScreenManager.cs
+++ b/src/ScreenManager.cs
@@ -61,6 +61,36 @@ public static class ScreenManager
     }
 
     /// <summary>
+    /// Returns the 0-based index of the primary screen (where the system tray lives).
+    /// Returns 0 if no primary screen is found.
+    /// </summary>
+    public static int GetPrimaryScreenIndex()
+    {
+        Screen[] screens = Screen.AllScreens;
+        for (int i = 0; i < screens.Length; i++)
+        {
+            if (screens[i].Primary)
+                return i;
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// Returns a list of screens for the given indices (skipping invalid ones).
+    /// </summary>
+    public static List<Screen> GetScreens(IEnumerable<int> indices)
+    {
+        Screen[] screens = Screen.AllScreens;
+        var result = new List<Screen>();
+        foreach (int i in indices)
+        {
+            if (i >= 0 && i < screens.Length)
+                result.Add(screens[i]);
+        }
+        return result;
+    }
+
+    /// <summary>
     /// Sets or removes the "Start with Windows" registry entry.
     /// </summary>
     public static void SetStartWithWindows(bool enable)

--- a/src/SettingsForm.cs
+++ b/src/SettingsForm.cs
@@ -1,12 +1,12 @@
 namespace BlackScreenSaver;
 
 /// <summary>
-/// Settings dialog allowing the user to choose which screen to black out,
+/// Settings dialog allowing the user to choose which screens to black out,
 /// set the inactivity timeout, and toggle "Start with Windows".
 /// </summary>
 public class SettingsForm : Form
 {
-    private readonly ComboBox _screenCombo;
+    private readonly ScreenLayoutPanel _screenPanel;
     private readonly NumericUpDown _timeoutUpDown;
     private readonly CheckBox _startWithWindowsCheckBox;
     private readonly Button _saveButton;
@@ -26,73 +26,82 @@ public class SettingsForm : Form
         MaximizeBox = false;
         MinimizeBox = false;
         StartPosition = FormStartPosition.CenterScreen;
-        Size = new Size(420, 230);
         ShowInTaskbar = true;
         TopMost = true;
 
-        // --- Screen selection ---
+        // --- Compute panel height based on screen layout aspect ratio ---
+        int panelWidth = 390;
+        int panelHeight = ComputePanelHeight(panelWidth);
+        int panelTop = 36;
+        int panelBottom = panelTop + panelHeight;
+
+        // --- Screen layout panel ---
         _screenLabel = new Label
         {
-            Text = "Target Screen:",
-            Location = new Point(20, 22),
-            AutoSize = true
+            Text = "Click screens to select for blackout:",
+            Location = new Point(20, 14),
+            AutoSize = true,
+            ForeColor = Color.FromArgb(80, 80, 80)
         };
 
-        _screenCombo = new ComboBox
+        int primaryIdx = ScreenManager.GetPrimaryScreenIndex();
+        var selectedIndices = new HashSet<int>(currentConfig.TargetScreenIndices ?? new List<int> { 1 });
+        selectedIndices.Remove(primaryIdx); // primary screen can never be selected
+
+        _screenPanel = new ScreenLayoutPanel
         {
-            DropDownStyle = ComboBoxStyle.DropDownList,
-            Location = new Point(140, 18),
-            Width = 240
+            Location = new Point(20, panelTop),
+            Size = new Size(panelWidth, panelHeight),
+            BorderStyle = BorderStyle.FixedSingle,
+            SelectedIndices = selectedIndices,
+            LockedIndices = new HashSet<int> { primaryIdx }
         };
-
-        string[] screenNames = ScreenManager.GetAllScreenDisplayNames();
-        _screenCombo.Items.AddRange(screenNames);
-
-        int selectedIndex = currentConfig.TargetScreenIndex;
-        if (selectedIndex >= 0 && selectedIndex < screenNames.Length)
-            _screenCombo.SelectedIndex = selectedIndex;
-        else if (screenNames.Length > 0)
-            _screenCombo.SelectedIndex = 0;
 
         // --- Timeout ---
+        int row1 = panelBottom + 18;
         _timeoutLabel = new Label
         {
             Text = "Timeout:",
-            Location = new Point(20, 62),
+            Location = new Point(20, row1 + 4),
             AutoSize = true
         };
 
         _timeoutUpDown = new NumericUpDown
         {
             Minimum = 1,
-            Maximum = 300,
-            Value = Math.Clamp(currentConfig.InactivityTimeoutSeconds, 1, 300),
-            Location = new Point(140, 58),
+            Maximum = 9999,
+            Value = Math.Max(currentConfig.InactivityTimeoutSeconds, 1),
+            Location = new Point(140, row1),
             Width = 80
         };
+        _timeoutUpDown.ValueChanged += OnTimeoutValueChanged;
+        _timeoutUpDown.Leave += OnTimeoutLeave;
+        UpdateTimeoutColor();
 
         _secondsLabel = new Label
         {
             Text = "seconds",
-            Location = new Point(226, 62),
+            Location = new Point(226, row1 + 4),
             AutoSize = true
         };
 
         // --- Start with Windows ---
+        int row2 = row1 + 38;
         _startWithWindowsCheckBox = new CheckBox
         {
             Text = "Start with Windows",
-            Location = new Point(140, 98),
+            Location = new Point(140, row2),
             AutoSize = true,
             Checked = currentConfig.StartWithWindows
         };
 
         // --- Buttons ---
+        int buttonRow = row2 + 40;
         _saveButton = new Button
         {
             Text = "Save",
             DialogResult = DialogResult.OK,
-            Location = new Point(200, 148),
+            Location = new Point(220, buttonRow),
             Width = 85
         };
         _saveButton.Click += OnSaveClick;
@@ -101,27 +110,93 @@ public class SettingsForm : Form
         {
             Text = "Cancel",
             DialogResult = DialogResult.Cancel,
-            Location = new Point(295, 148),
+            Location = new Point(315, buttonRow),
             Width = 85
         };
 
         AcceptButton = _saveButton;
         CancelButton = _cancelButton;
 
+        // Set form size to fit all controls
+        Size = new Size(440, buttonRow + 75);
+
         Controls.AddRange(new Control[]
         {
-            _screenLabel, _screenCombo,
+            _screenLabel, _screenPanel,
             _timeoutLabel, _timeoutUpDown, _secondsLabel,
             _startWithWindowsCheckBox,
             _saveButton, _cancelButton
         });
     }
 
+    /// <summary>
+    /// Computes the ideal panel height based on the aspect ratio of
+    /// the combined screen bounding box. Clamped to [100, 300].
+    /// </summary>
+    private static int ComputePanelHeight(int panelWidth)
+    {
+        Screen[] screens = Screen.AllScreens;
+        if (screens.Length == 0)
+            return 160;
+
+        int minX = int.MaxValue, minY = int.MaxValue;
+        int maxX = int.MinValue, maxY = int.MinValue;
+
+        foreach (Screen s in screens)
+        {
+            if (s.Bounds.Left < minX) minX = s.Bounds.Left;
+            if (s.Bounds.Top < minY) minY = s.Bounds.Top;
+            if (s.Bounds.Right > maxX) maxX = s.Bounds.Right;
+            if (s.Bounds.Bottom > maxY) maxY = s.Bounds.Bottom;
+        }
+
+        float totalW = maxX - minX;
+        float totalH = maxY - minY;
+        if (totalW <= 0) return 160;
+
+        float aspect = totalH / totalW;
+        int height = (int)(panelWidth * aspect);
+
+        // Clamp to reasonable range
+        return Math.Clamp(height, 100, 300);
+    }
+
+    private void OnTimeoutValueChanged(object? sender, EventArgs e)
+    {
+        UpdateTimeoutColor();
+    }
+
+    private void OnTimeoutLeave(object? sender, EventArgs e)
+    {
+        if (_timeoutUpDown.Value > 300)
+            _timeoutUpDown.Value = 300;
+        UpdateTimeoutColor();
+    }
+
+    private void UpdateTimeoutColor()
+    {
+        _timeoutUpDown.ForeColor = _timeoutUpDown.Value > 300 ? Color.Red : SystemColors.WindowText;
+    }
+
     private void OnSaveClick(object? sender, EventArgs e)
     {
+        var selectedIndices = _screenPanel.SelectedIndices.ToList();
+        if (selectedIndices.Count == 0)
+        {
+            MessageBox.Show("Please select at least one screen.", "Settings",
+                MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            DialogResult = DialogResult.None;
+            return;
+        }
+
+        // Clamp timeout to 300 on save as well
+        if (_timeoutUpDown.Value > 300)
+            _timeoutUpDown.Value = 300;
+
+        selectedIndices.Sort();
         ResultConfig = new AppConfig
         {
-            TargetScreenIndex = _screenCombo.SelectedIndex >= 0 ? _screenCombo.SelectedIndex : 0,
+            TargetScreenIndices = selectedIndices,
             InactivityTimeoutSeconds = (int)_timeoutUpDown.Value,
             StartWithWindows = _startWithWindowsCheckBox.Checked
         };


### PR DESCRIPTION
## Summary

The primary screen (where the system tray / taskbar resides) can no longer be selected for blackout. This prevents the user from accidentally blacking out their main working screen.

## Changes

- **ScreenManager**: Added `GetPrimaryScreenIndex()` helper that returns the index of the primary display
- **ScreenLayoutPanel**: 
  - New `LockedIndices` property — screens in this set cannot be toggled
  - Primary screen rendered with darker fill and "Primary (locked)" label
  - Click on locked screen is a no-op; cursor stays default (no hand pointer)
- **SettingsForm**: Strips primary index from selection on form init, passes `LockedIndices` to panel
- **ConfigManager**: On load, removes primary screen index from `TargetScreenIndices`
- **TrayApplicationContext**: Display-change handler now also excludes the primary screen index