### PR TITLE
fix: skip overlay when fullscreen app is active

### DIFF
--- a/src/TrayApplicationContext.cs
+++ b/src/TrayApplicationContext.cs
@@ -79,11 +79,16 @@ public class TrayApplicationContext : ApplicationContext
 
     /// <summary>
     /// Shows an overlay on a single screen by index.
+    /// Skips if a fullscreen app (video, game, slideshow) is detected on the screen.
     /// </summary>
     private void ShowOverlayForScreen(int screenIndex)
     {
         if (_screenOverlayMap.ContainsKey(screenIndex))
             return; // already showing
+
+        // Don't overlay if a fullscreen app is running on this screen
+        if (ScreenManager.IsScreenFullscreenOccupied(screenIndex))
+            return;
 
         Screen? screen = ScreenManager.GetScreen(screenIndex);
         if (screen == null) return;


### PR DESCRIPTION
## Problem

The black overlay would appear on top of fullscreen applications (videos, games, slideshows), disrupting the user experience.

## Solution

Added fullscreen detection using Windows P/Invoke:
- `IsScreenFullscreenOccupied(int screenIndex)` checks if the foreground window matches the screen bounds (with 5px tolerance for edge cases)
- Before showing an overlay, check if a fullscreen app is active on that screen
- If fullscreen is detected, skip displaying the overlay

## Behavior

- Watching a video on a selected screen → overlay does **not** appear
- Playing a game → overlay does **not** appear
- Running a slideshow → overlay does **not** appear
- When fullscreen app closes or user switches away → inactivity timer resumes and overlay will appear on next timeout