### PR TITLE
fix: enable PerMonitorV2 DPI mode to fix context menu on wrong screen

### DIFF
--- a/BlackScreenSaver.csproj
+++ b/BlackScreenSaver.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>BlackScreenSaver</RootNamespace>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Problem
Right-clicking the tray icon sometimes opens the context menu on the wrong screen (not near the icon) and scaled up, on multi-monitor setups with different DPI scaling (issue #6).

## Root Cause
The application was using the default `SystemAware` DPI mode, which applies a single system-wide DPI to all monitors. On setups with monitors at different scaling (e.g., 100% and 150%), this causes Windows to miscalculate coordinates for the context menu, placing it on the wrong screen with incorrect scaling.

## Solution
Added `<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>` to the project file. This enables per-monitor DPI awareness so each monitor gets its own correct DPI handling, ensuring the context menu appears at the correct position near the tray icon.

Closes #6