### PR TITLE
fix: overlay window fills entire screen under PerMonitorV2 DPI

### DIFF
--- a/src/OverlayWindow.cs
+++ b/src/OverlayWindow.cs
@@ -6,6 +6,8 @@ namespace BlackScreenSaver;
 /// </summary>
 public class OverlayWindow : Form
 {
+    private Screen? _targetScreen;
+
     public OverlayWindow()
     {
         FormBorderStyle = FormBorderStyle.None;
@@ -14,6 +16,10 @@ public class OverlayWindow : Form
         ShowInTaskbar = false;
         StartPosition = FormStartPosition.Manual;
         DoubleBuffered = true;
+
+        // Disable auto-scaling so WinForms doesn't resize the form
+        // when it enters a monitor with a different DPI (PerMonitorV2).
+        AutoScaleMode = AutoScaleMode.None;
 
         // Ensure the form is created so we can call Show/Hide later
         // without cross-thread issues.
@@ -31,10 +37,27 @@ public class OverlayWindow : Form
             return;
         }
 
+        _targetScreen = screen;
         Bounds = screen.Bounds;
         if (!Visible)
         {
             Show();
+            // Re-apply bounds after Show() in case the DPI change
+            // during window creation altered the size.
+            Bounds = screen.Bounds;
+        }
+    }
+
+    /// <summary>
+    /// When the overlay moves to a screen with a different DPI,
+    /// force the bounds back to the full screen size.
+    /// </summary>
+    protected override void OnDpiChanged(DpiChangedEventArgs e)
+    {
+        base.OnDpiChanged(e);
+        if (_targetScreen != null)
+        {
+            Bounds = _targetScreen.Bounds;
         }
     }
 


### PR DESCRIPTION
## Problem

After enabling `PerMonitorV2` DPI mode (PR #8), the black overlay shrinks to a small rectangle in the screen corner on high-DPI monitors. WinForms' default `AutoScaleMode.Font` rescales the form's bounds by the DPI ratio when the window lands on a non-primary monitor with different scaling.

## Fix

Three changes to `OverlayWindow`:

1. **`AutoScaleMode = AutoScaleMode.None`** — the overlay has no controls or fonts to scale, so auto-scaling only causes harm.
2. **Re-apply `Bounds` after `Show()`** — catches any size change that happens during window creation on a high-DPI monitor.
3. **`OnDpiChanged` override** — forces bounds back to full-screen if the system fires a DPI change event while the overlay is visible.