### PR TITLE
fix: black out now overlay doesn't disappear on mouse hover

### DIFF
--- a/src/CursorMonitor.cs
+++ b/src/CursorMonitor.cs
@@ -120,6 +120,16 @@ public class CursorMonitor : IDisposable
         }
     }
 
+    /// <summary>
+    /// Externally marks a screen as having an active overlay so the monitor
+    /// will fire <see cref="ActivityDetected"/> when the cursor enters it.
+    /// Used by "Black Out Now" which bypasses the inactivity timeout.
+    /// </summary>
+    public void MarkOverlayActive(int screenIndex)
+    {
+        _activeOverlayScreens.Add(screenIndex);
+    }
+
     public void Dispose()
     {
         _timer.Stop();

--- a/src/TrayApplicationContext.cs
+++ b/src/TrayApplicationContext.cs
@@ -97,6 +97,12 @@ public class TrayApplicationContext : ApplicationContext
         overlay.ShowOnScreen(screen);
         _overlays.Add(overlay);
         _screenOverlayMap[screenIndex] = overlay;
+
+        // Ensure the cursor monitor knows an overlay is active so it will
+        // fire ActivityDetected when the cursor enters this screen.
+        // (Required for the "Black Out Now" path which bypasses the
+        //  inactivity timeout and therefore never sets this flag itself.)
+        _monitor.MarkOverlayActive(screenIndex);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Fixes #11 — "Black Out Now" creates a black overlay that doesn't disappear when the mouse cursor moves over it.

## Root Cause

When using "Black Out Now", the overlay was created via `ShowOverlayForScreen()` but `CursorMonitor._activeOverlayScreens` was never populated. This set is only updated in the normal inactivity timeout path inside `OnTimerTick()`. Without the screen index in `_activeOverlayScreens`, the cursor monitor never fires `ActivityDetected`, so the overlay stays forever.

## Fix

- Added `MarkOverlayActive(int screenIndex)` to `CursorMonitor` — allows external callers to register a screen as having an active overlay.
- Called `_monitor.MarkOverlayActive(screenIndex)` at the end of `ShowOverlayForScreen()` so both the timeout path and the manual "Black Out Now" path keep the cursor monitor in sync.

Since `_activeOverlayScreens` is a `HashSet`, the duplicate add from the timeout path is a harmless no-op.