### PR TITLE
fix: persist screen selection by device name instead of unstable array index

### DIFF
--- a/BlackScreenSaver.csproj
+++ b/BlackScreenSaver.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <Version>1.1.0</Version>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>

--- a/src/Config.cs
+++ b/src/Config.cs
@@ -7,9 +7,15 @@ public class AppConfig
 {
     /// <summary>
     /// Indices of the target screens to black out (0-based).
-    /// Multiple screens can be selected.
+    /// Derived at runtime from <see cref="TargetScreenDeviceNames"/>.
     /// </summary>
     public List<int> TargetScreenIndices { get; set; } = new() { 1 };
+
+    /// <summary>
+    /// Stable device names (e.g. \\.\DISPLAY3) for the target screens.
+    /// This is the persisted source of truth — indices are resolved from these on load.
+    /// </summary>
+    public List<string> TargetScreenDeviceNames { get; set; } = new();
 
     /// <summary>
     /// Legacy property kept for backward-compatible deserialization.

--- a/src/ConfigManager.cs
+++ b/src/ConfigManager.cs
@@ -19,6 +19,7 @@ public static class ConfigManager
 
     /// <summary>
     /// Loads configuration from disk, or returns defaults if the file doesn't exist.
+    /// Resolves stable device names to current screen indices.
     /// </summary>
     public static AppConfig Load()
     {
@@ -37,14 +38,34 @@ public static class ConfigManager
                         config.TargetScreenIndices = new List<int> { config.TargetScreenIndex.Value };
                     }
                     config.TargetScreenIndex = null;
-                    Save(config); // persist migration
                 }
 
                 config.TargetScreenIndices ??= new List<int> { 1 };
+                config.TargetScreenDeviceNames ??= new List<string>();
 
-                // Strip out the primary screen index — it must never be blacked out
+                bool needsSave = false;
+                Screen[] screens = Screen.AllScreens;
+
+                if (config.TargetScreenDeviceNames.Count > 0)
+                {
+                    // Resolve device names to current indices (stable across reboots)
+                    config.TargetScreenIndices = ResolveDeviceNamesToIndices(config.TargetScreenDeviceNames, screens);
+                }
+                else if (config.TargetScreenIndices.Count > 0)
+                {
+                    // Legacy config without device names — migrate
+                    config.TargetScreenDeviceNames = ResolveIndicesToDeviceNames(config.TargetScreenIndices, screens);
+                    needsSave = true;
+                }
+
+                // Strip out the primary screen — it must never be blacked out
                 int primaryIdx = ScreenManager.GetPrimaryScreenIndex();
+                string? primaryDeviceName = primaryIdx >= 0 && primaryIdx < screens.Length
+                    ? screens[primaryIdx].DeviceName : null;
+
                 config.TargetScreenIndices.Remove(primaryIdx);
+                if (primaryDeviceName != null)
+                    config.TargetScreenDeviceNames.Remove(primaryDeviceName);
 
                 // If this leaves no target screens (for example, single-monitor setups),
                 // fall back to the primary screen so the app remains functional.
@@ -52,6 +73,9 @@ public static class ConfigManager
                 {
                     config.TargetScreenIndices.Add(primaryIdx);
                 }
+
+                if (needsSave)
+                    Save(config);
 
                 return config;
             }
@@ -62,6 +86,42 @@ public static class ConfigManager
         }
 
         return new AppConfig();
+    }
+
+    /// <summary>
+    /// Resolves a list of device names to current screen indices.
+    /// Unrecognized device names are silently skipped.
+    /// </summary>
+    public static List<int> ResolveDeviceNamesToIndices(List<string> deviceNames, Screen[] screens)
+    {
+        var indices = new List<int>();
+        foreach (string name in deviceNames)
+        {
+            for (int i = 0; i < screens.Length; i++)
+            {
+                if (string.Equals(screens[i].DeviceName, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    indices.Add(i);
+                    break;
+                }
+            }
+        }
+        return indices;
+    }
+
+    /// <summary>
+    /// Resolves a list of screen indices to their device names.
+    /// Out-of-range indices are silently skipped.
+    /// </summary>
+    public static List<string> ResolveIndicesToDeviceNames(List<int> indices, Screen[] screens)
+    {
+        var names = new List<string>();
+        foreach (int idx in indices)
+        {
+            if (idx >= 0 && idx < screens.Length)
+                names.Add(screens[idx].DeviceName);
+        }
+        return names;
     }
 
     /// <summary>

--- a/src/SettingsForm.cs
+++ b/src/SettingsForm.cs
@@ -194,9 +194,20 @@ public class SettingsForm : Form
             _timeoutUpDown.Value = 300;
 
         selectedIndices.Sort();
+
+        // Persist stable device names alongside indices
+        Screen[] screens = Screen.AllScreens;
+        var deviceNames = new List<string>();
+        foreach (int idx in selectedIndices)
+        {
+            if (idx >= 0 && idx < screens.Length)
+                deviceNames.Add(screens[idx].DeviceName);
+        }
+
         ResultConfig = new AppConfig
         {
             TargetScreenIndices = selectedIndices,
+            TargetScreenDeviceNames = deviceNames,
             InactivityTimeoutSeconds = (int)_timeoutUpDown.Value,
             StartWithWindows = _startWithWindowsCheckBox.Checked
         };

--- a/src/TrayApplicationContext.cs
+++ b/src/TrayApplicationContext.cs
@@ -183,16 +183,28 @@ public class TrayApplicationContext : ApplicationContext
 
     private void OnDisplaySettingsChanged(object? sender, EventArgs e)
     {
-        // Remove any indices that are now out of range or point at the primary screen
-        int screenCount = Screen.AllScreens.Length;
+        Screen[] screens = Screen.AllScreens;
         int primaryIdx = ScreenManager.GetPrimaryScreenIndex();
-        var validIndices = _config.TargetScreenIndices.Where(i => i < screenCount && i != primaryIdx).ToList();
-        if (validIndices.Count != _config.TargetScreenIndices.Count)
+        string? primaryDeviceName = primaryIdx >= 0 && primaryIdx < screens.Length
+            ? screens[primaryIdx].DeviceName : null;
+
+        // Re-resolve device names to current indices (screen order may have changed)
+        if (_config.TargetScreenDeviceNames.Count > 0)
         {
-            _config.TargetScreenIndices = validIndices.Count > 0 ? validIndices : new List<int> { 0 };
-            _monitor.TargetScreenIndices = new HashSet<int>(_config.TargetScreenIndices);
-            ConfigManager.Save(_config);
+            _config.TargetScreenIndices = ConfigManager.ResolveDeviceNamesToIndices(
+                _config.TargetScreenDeviceNames, screens);
         }
+
+        // Exclude primary screen
+        _config.TargetScreenIndices.Remove(primaryIdx);
+        if (primaryDeviceName != null)
+            _config.TargetScreenDeviceNames.Remove(primaryDeviceName);
+
+        if (_config.TargetScreenIndices.Count == 0)
+            _config.TargetScreenIndices.Add(0);
+
+        _monitor.TargetScreenIndices = new HashSet<int>(_config.TargetScreenIndices);
+        ConfigManager.Save(_config);
     }
 
     private void ExitApplication()


### PR DESCRIPTION
## Problem

After Windows reboots, the screensaver would select the wrong monitor. For example, the user selects Screen 3 (laptop), but after reboot Screen 2 (external monitor) gets blacked out instead.

## Root Cause

Screen selection was stored as array indices into `Screen.AllScreens`, which is **not guaranteed to maintain the same order** across Windows reboots, display driver reloads, or monitor plug/unplug events.

## Fix

- Added `TargetScreenDeviceNames` to config — stores stable `Screen.DeviceName` values (e.g. `\\.\DISPLAY3`) as the source of truth
- On startup, resolves device names → current array indices via `Screen.AllScreens` matching
- On display settings change, re-resolves device names to updated indices
- Settings form now saves both device names and indices
- Auto-migrates legacy configs that only had `TargetScreenIndices`
- Fully backward compatible

## Changed Files

- `src/Config.cs` — Added `TargetScreenDeviceNames` property
- `src/ConfigManager.cs` — Device name resolution + legacy migration logic
- `src/SettingsForm.cs` — Save device names on settings save
- `src/TrayApplicationContext.cs` — Re-resolve on display changes
- `BlackScreenSaver.csproj` — Version bump to 1.1.0

## Version

`v1.1.0`